### PR TITLE
Add mean and variance attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,10 @@ The format is based on `Keep a Changelog
 * Add ``opda.exceptions.NumericalError``, an exception for numerical
   issues.
 * Add more tests for ``opda.parametric.QuadraticDistribution``.
+* Add ``mean`` and ``variance`` attributes to
+  ``opda.nonparametric.EmpiricalDistribution``.
+* Add ``mean`` and ``variance`` attributes to
+  ``opda.parametric.QuadraticDistribution``.
 
 .. rubric:: Changes
 

--- a/src/opda/nonparametric.py
+++ b/src/opda/nonparametric.py
@@ -172,6 +172,13 @@ class EmpiricalDistribution:
     b : float, optional (default=np.inf)
         The maximum of the support of the underlying distribution.
 
+    Attributes
+    ----------
+    mean : float
+        The distribution's mean.
+    variance : float
+        The distribution's variance.
+
     Notes
     -----
     :py:class:`EmpiricalDistribution` provides confidence bands for the
@@ -246,11 +253,24 @@ class EmpiricalDistribution:
                 f"b ({b}) cannot be less than the max of ys ({np.max(ys)}).",
             )
 
-        # Bind arguments to attributes.
+        # Bind arguments to the instance as attributes.
         self.ys = ys
         self.ws = ws
         self.a = a
         self.b = b
+
+        # Bind other attributes to the instance.
+        with np.errstate(invalid="ignore"):
+            self.mean = (
+                np.mean(ys)
+                if ws is None else
+                np.sum(ws * ys, where=ws > 0.)
+            )
+            self.variance = (
+                np.var(ys)
+                if ws is None else
+                np.sum(ws * (ys - self.mean)**2, where=ws > 0.)
+            )
 
         # Handle duplicate values in ys and default value for ws.
         _ys, locations, counts = np.unique(
@@ -296,7 +316,7 @@ class EmpiricalDistribution:
             np.concatenate([[0.] * len(prepend), _ws, [0.] * len(postpend)]),
         )
 
-        # Initialize useful attributes.
+        # Initialize useful private attributes.
         self._ws_cumsum = _normalize_cdf(np.cumsum(self._ws))
         self._ws_cumsum_prev = np.concatenate([[0.], self._ws_cumsum[:-1]])
 

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -29,6 +29,13 @@ class QuadraticDistribution:
         distribution, as opposed to the concave form. When optimizing
         via random search, the tail of the score distribution approaches
         the convex form when minimizing and the concave when maximizing.
+
+    Attributes
+    ----------
+    mean : float
+        The distribution's mean.
+    variance : float
+        The distribution's variance.
     """
 
     def __init__(
@@ -58,11 +65,19 @@ class QuadraticDistribution:
         if a > b:
             raise ValueError("a must be less than or equal to b.")
 
-        # Bind attributes to the instance.
+        # Bind arguments to the instance as attributes.
         self.a = a
         self.b = b
         self.c = c
         self.convex = convex
+
+        # Bind other attributes to the instance.
+        self.mean = (
+            a + (b - a) * c / (c + 2)
+            if convex else
+            a + (b - a) * 2 / (c + 2)
+        )
+        self.variance = (b - a)**2 * 4 * c / ((c + 2)**2 * (c + 4))
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -13,6 +13,28 @@ from tests import testcases
 class QuadraticDistributionTestCase(testcases.RandomTestCase):
     """Test opda.parametric.QuadraticDistribution."""
 
+    @pytest.mark.level(1)
+    def test_attributes(self):
+        n_samples = 1_000_000
+
+        bounds = [(-10., -1.), (-1., 0.), (-1., 1.), (0., 1.), (1., 10.)]
+        cs = [1, 2, 20]
+        for a, b in bounds:
+            for c in cs:
+                for convex in [False, True]:
+                    dist = parametric.QuadraticDistribution(a, b, c, convex)
+                    ys = dist.sample(n_samples)
+                    self.assertAlmostEqual(
+                        dist.mean,
+                        np.mean(ys),
+                        delta=6 * np.std(ys) / n_samples**0.5,
+                    )
+                    self.assertAlmostEqual(
+                        dist.variance,
+                        np.mean((ys - dist.mean)**2),
+                        delta=6 * np.std((ys - dist.mean)**2) / n_samples**0.5,
+                    )
+
     def test___eq__(self):
         bounds = [(-10., -1.), (-1., 0.), (-1., 1.), (0., 1.), (1., 10.)]
         cs = [1, 2, 20]


### PR DESCRIPTION
Add `mean` and `variance` attributes to `opda.nonparametic.EmpiricalDistribution` and `opda.parametric.QuadraticDistribution`.