### PR TITLE
Coerce scalars to numpy numeric types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,8 @@ The format is based on `Keep a Changelog
   effective number of hyperparameters instead of half the number.
 * Completely disable the eradicate (``ERA``) lint rules.
 * Enable ``"py"`` as the primary domain in the documentation.
+* Always use numpy's numeric types for scalar class attributes,
+  instead of Python's native numeric types.
 
 .. rubric:: Deprecations
 .. rubric:: Removals

--- a/src/opda/approximation.py
+++ b/src/opda/approximation.py
@@ -146,12 +146,15 @@ def remez(f, a, b, n, *, atol=None):
     if not callable(f):
         raise TypeError("f must be callable.")
 
+    a = np.array(a)[()]
     if not np.isscalar(a):
         raise ValueError("a must be a scalar.")
 
+    b = np.array(b)[()]
     if not np.isscalar(b):
         raise ValueError("b must be a scalar.")
 
+    n = np.array(n)[()]
     if not np.isscalar(n):
         raise ValueError("n must be a scalar.")
     if n % 1 != 0:
@@ -417,12 +420,15 @@ def minimax_polynomial_approximation(f, a, b, n, *, atol=None):
     if not callable(f):
         raise TypeError("f must be callable.")
 
+    a = np.array(a)[()]
     if not np.isscalar(a):
         raise ValueError("a must be a scalar.")
 
+    b = np.array(b)[()]
     if not np.isscalar(b):
         raise ValueError("b must be a scalar.")
 
+    n = np.array(n)[()]
     if not np.isscalar(n):
         raise ValueError("n must be a scalar.")
     if n % 1 != 0:
@@ -535,12 +541,15 @@ def minimax_polynomial_coefficients(
     if not callable(f):
         raise TypeError("f must be callable.")
 
+    a = np.array(a)[()]
     if not np.isscalar(a):
         raise ValueError("a must be a scalar.")
 
+    b = np.array(b)[()]
     if not np.isscalar(b):
         raise ValueError("b must be a scalar.")
 
+    n = np.array(n)[()]
     if not np.isscalar(n):
         raise ValueError("n must be a scalar.")
     if n % 1 != 0:
@@ -713,9 +722,11 @@ def piecewise_polynomial_knots(f, a, b, ns, *, atol=None):
     if not callable(f):
         raise TypeError("f must be callable.")
 
+    a = np.array(a)[()]
     if not np.isscalar(a):
         raise ValueError("a must be a scalar.")
 
+    b = np.array(b)[()]
     if not np.isscalar(b):
         raise ValueError("b must be a scalar.")
 

--- a/src/opda/nonparametric.py
+++ b/src/opda/nonparametric.py
@@ -239,6 +239,7 @@ class EmpiricalDistribution:
             if np.abs(np.sum(ws) - 1.) > 1e-10:
                 raise ValueError("ws must sum to 1.")
 
+        a = np.array(a)[()]
         if not np.isscalar(a):
             raise ValueError("a must be a scalar.")
         if a > np.min(ys):
@@ -246,6 +247,7 @@ class EmpiricalDistribution:
                 f"a ({a}) cannot be greater than the min of ys ({np.min(ys)}).",
             )
 
+        b = np.array(b)[()]
         if not np.isscalar(b):
             raise ValueError("b must be a scalar.")
         if b < np.max(ys):
@@ -827,6 +829,7 @@ class EmpiricalDistribution:
                 stacklevel=2,
             )
 
+        confidence = np.array(confidence)[()]
         if not np.isscalar(confidence):
             raise ValueError("confidence must be a scalar.")
         if confidence < 0. or confidence > 1.:
@@ -834,6 +837,7 @@ class EmpiricalDistribution:
                 "confidence must be between 0 and 1, inclusive.",
             )
 
+        a = np.array(a)[()]
         if not np.isscalar(a):
             raise ValueError("a must be a scalar.")
         if a > np.min(ys):
@@ -841,6 +845,7 @@ class EmpiricalDistribution:
                 f"a ({a}) cannot be greater than the min of ys ({np.min(ys)}).",
             )
 
+        b = np.array(b)[()]
         if not np.isscalar(b):
             raise ValueError("b must be a scalar.")
         if b < np.max(ys):

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -46,12 +46,15 @@ class QuadraticDistribution:
             convex = False,
     ):
         # Validate the arguments.
+        a = np.array(a)[()]
         if not np.isscalar(a):
             raise ValueError("a must be a scalar.")
 
+        b = np.array(b)[()]
         if not np.isscalar(b):
             raise ValueError("b must be a scalar.")
 
+        c = np.array(c)[()]
         if not np.isscalar(c):
             raise ValueError("c must be a scalar.")
         if c % 1 != 0:
@@ -265,6 +268,7 @@ class QuadraticDistribution:
         if np.any(ns <= 0):
             raise ValueError("ns must be positive.")
 
+        q = np.array(q)[()]
         if not np.isscalar(q):
             raise ValueError("q must be a scalar.")
         if q < 0. or q > 1.:
@@ -380,6 +384,7 @@ class QuadraticDistribution:
         if len(ys) == 0:
             raise ValueError("ys must be non-empty.")
 
+        fraction = np.array(fraction)[()]
         if not np.isscalar(fraction):
             raise ValueError("fraction must be a scalar.")
         if fraction < 0. or fraction > 1.:


### PR DESCRIPTION
Numpy's and Python's numeric types don't behave exactly the same in all circumstances. Thus, coerce all scalars to numpy's numeric types in order to ensure consistent behavior.