### PR TITLE
Improve docs and comments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,6 +84,10 @@ The format is based on `Keep a Changelog
 * Improve the docstring for
   ``experiments.analytic.get_approximation_parameters``.
 * Use inline math markup in docstrings.
+* Fix the equation in the docstring for
+  ``opda.parametric.QuadraticDistribution.ppf``. The infimum that
+  defines the quantile function has as its domain the interval from
+  ``a`` to ``b``, not the entire real line.
 
 .. rubric:: Security
 

--- a/src/opda/nonparametric.py
+++ b/src/opda/nonparametric.py
@@ -413,7 +413,7 @@ class EmpiricalDistribution:
             self._ys[indices] == ys,
             self._ws[indices],
             0,
-        )[()]  # If the result is a 0d array, convert to scalar.
+        )[()]
 
     def cdf(self, ys):
         r"""Return the cumulative probability at ``ys``.

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -162,11 +162,12 @@ class QuadraticDistribution:
                 ps = (c / (2*(b - a))) * ((ys - a) / (b - a))**(c/2 - 1)
             else:  # concave
                 ps = (c / (2*(b - a))) * ((b - ys) / (b - a))**(c/2 - 1)
+
         ps = np.where(
             (ys < a) | (ys > b),
             0.,
             ps,
-        )[()]  # If the result is a 0d array, convert to scalar.
+        )[()]
 
         return ps
 
@@ -278,6 +279,7 @@ class QuadraticDistribution:
         if not isinstance(minimize, bool):
             raise TypeError("minimize must be a boolean.")
 
+        # Compute the quantile tuning curve.
         a, b, c = self.a, self.b, self.c
 
         if self.convex:
@@ -321,6 +323,7 @@ class QuadraticDistribution:
         if not isinstance(minimize, bool):
             raise TypeError("minimize must be a boolean.")
 
+        # Compute the average tuning curve.
         a, b, c = self.a, self.b, self.c
 
         if self.convex:
@@ -419,7 +422,7 @@ class QuadraticDistribution:
             b = a + (b - a) / fraction**(2/c)
             # Push b a little higher.
             b = b + 0.05 * (b - a)
-        else:
+        else:  # concave
             # Push b a bit higher than max(ys).
             b = b + 0.05 * (b - a)
             # Set a so that P(y > ys_fraction[0]) = fraction.

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -213,7 +213,7 @@ class QuadraticDistribution:
 
         .. math::
 
-           Q(p) = \inf \{y\in\mathbb{R}\mid p\leq F(y)\}
+           Q(p) = \inf \{y\in[a, b]\mid p\leq F(y)\}
 
         where :math:`F` is the cumulative distribution function.
 

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -245,6 +245,7 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
                     dist.cdf(a + (n / 5.) * (b - a)),
                     n / 5.,
                 )
+            # broadcasting
             for _ in range(7):
                 # 1D array
                 us = self.generator.uniform(0, 1, size=5)
@@ -283,6 +284,7 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
                 self.assertTrue(np.isscalar(dist.ppf(n / 5.)))
                 # When c = 2, the distribution is uniform.
                 self.assertAlmostEqual(dist.ppf(n / 5.), a + (n / 5.) * (b - a))
+            # broadcasting
             for _ in range(7):
                 # 1D array
                 us = self.generator.uniform(0, 1, size=5)
@@ -800,6 +802,8 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
     @pytest.mark.level(1)
     def test_cdf_agrees_with_sampling_definition(self):
         for a, b in [(-1., 1.), (0., 1.), (1., 10.)]:
+            # NOTE: Keep c low because the rejection sampling below will
+            # reject too many samples for large c.
             for c in [1, 2, 3]:
                 for convex in [False, True]:
                     dist = parametric.QuadraticDistribution(


### PR DESCRIPTION
Fix an error in the docstring for `opda.parametric.QuadraticDistribution.ppf` and improve the code comments.