### PR TITLE
Fix QuadraticDistribution when a equals b

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,10 +77,18 @@ The format is based on `Keep a Changelog
   instead of Python's native numeric types.
 * Improve tests for ``parametric.QuadraticDistribution``, making them
   more thorough, robust, and avoiding re-running redundant test cases.
+* Update the tests for ``parametric.QuadraticDistribution`` to cover
+  the case when ``a == b``.
 
 .. rubric:: Deprecations
 .. rubric:: Removals
 .. rubric:: Fixes
+
+* Fix ``parametric.QuadraticDistribution`` (the ``.pdf``, ``.cdf``,
+  and ``.estimate_initial_parameters_and_bounds`` methods) for the
+  case when ``a == b``, in which case the distribution is an atom
+  (point mass).
+
 .. rubric:: Documentation
 
 * Improve the docstring for

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -157,6 +157,9 @@ class QuadraticDistribution:
 
         a, b, c = self.a, self.b, self.c
 
+        if a == b:
+            return np.where(ys == a, np.inf, 0.)[()]
+
         with np.errstate(divide="ignore", invalid="ignore"):
             if self.convex:
                 ps = (c / (2*(b - a))) * ((ys - a) / (b - a))**(c/2 - 1)
@@ -194,6 +197,9 @@ class QuadraticDistribution:
         ys = np.array(ys)
 
         a, b, c = self.a, self.b, self.c
+
+        if a == b:
+            return np.where(ys < a, 0., 1.)[()]
 
         # Handle values of y outside the support by clipping to a and b
         # since the CDF is 0 when y is below a and 1 when y is above b.
@@ -407,6 +413,12 @@ class QuadraticDistribution:
 
         a = ys_fraction[0]
         b = ys_fraction[-1]
+        if a == b:
+            return (
+                np.array([a, b, np.nan]),
+                np.array([(-np.inf, a), (b, np.inf), (0, np.inf)]),
+            )
+
         # Initialize c with its MLE assuming a and b are known.
         c = 2 * (
             1. / np.mean(np.log((b - a) / (ys_fraction[1:-1] - a)))


### PR DESCRIPTION
When `a == b`, the quadratic distribution is an atom (or point mass). The `QuadraticDistribution` class's `pdf`, `cdf`, and `estimate_initial_parameters_and_bounds` methods do not handle this case correctly. So, fix the class and add tests to cover this case.